### PR TITLE
fix: always use API skin_url for skin fetching

### DIFF
--- a/crates/coral-bot/src/commands/stats/bedwars.rs
+++ b/crates/coral-bot/src/commands/stats/bedwars.rs
@@ -242,15 +242,15 @@ async fn fetch_player_data(data: &Data, player: &str) -> Result<BedwarsCache, St
     let (resp, guild_result, skin_result, history_result) = match cached_uuid {
         Some(ref uuid) => {
             let cache_repo = CacheRepository::new(data.db.pool());
-            let (api, guild, skin, history) = tokio::join!(
+            let (api, guild, history) = tokio::join!(
                 data.api.get_player_stats(player),
                 data.api.get_guild(uuid, Some("player")),
-                data.skin_provider.fetch(uuid),
                 cache_repo.get_all_snapshots_mapped(uuid, extract_winstreak_snapshot),
             );
             let resp = api.map_err(map_api_error)?;
 
             if resp.uuid == *uuid {
+                let skin = fetch_skin(data, &resp.uuid, resp.skin_url.as_deref()).await;
                 (resp, guild, skin, history)
             } else {
                 let cache_repo = CacheRepository::new(data.db.pool());

--- a/crates/coral-bot/src/commands/stats/session.rs
+++ b/crates/coral-bot/src/commands/stats/session.rs
@@ -1085,13 +1085,13 @@ async fn fetch_player(
 > {
     match cached_uuid {
         Some(uuid) => {
-            let (api, guild, skin) = tokio::join!(
+            let (api, guild) = tokio::join!(
                 data.api.get_player_stats(player),
                 data.api.get_guild(uuid, Some("player")),
-                data.skin_provider.fetch(uuid),
             );
             let resp = api.map_err(map_api_error)?;
             if resp.uuid == uuid {
+                let skin = fetch_skin(data, &resp.uuid, resp.skin_url.as_deref()).await;
                 return Ok((resp, guild, skin));
             }
             let (guild, skin) = tokio::join!(


### PR DESCRIPTION
When the player UUID was cached, the skin was fetched without the Mojang texture URL (running in parallel before the API responded). This caused inconsistent slim/thick skin detection.

Now always uses `resp.skin_url` from the API response when fetching skins.

_P.S. could not build test since the `clients` crate is not public_